### PR TITLE
NetBox 4.3 compatibility

### DIFF
--- a/netbox_plugin_reloader/__init__.py
+++ b/netbox_plugin_reloader/__init__.py
@@ -25,8 +25,8 @@ class NetboxPluginReloaderConfig(PluginConfig):
     required_settings = []
 
     # NetBox version compatibility
-    min_version = "4.2.0"
-    max_version = "4.2.99"
+    min_version = "4.3.0"
+    max_version = "4.3.99"
 
     def ready(self):
         """

--- a/netbox_plugin_reloader/version.py
+++ b/netbox_plugin_reloader/version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.0.2"
+__version__ = "4.3.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated compatibility to support NetBox versions 4.3.0 through 4.3.99.
  - Updated plugin version to 4.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->