### PR TITLE
fix: Update plugin for NetBox 4.4 compatibility

### DIFF
--- a/netbox_plugin_reloader/version.py
+++ b/netbox_plugin_reloader/version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "4.4.0"
+__version__ = "4.4.0.1"


### PR DESCRIPTION
- Remove deprecated FEATURES_MAP import (replaced with dynamic registration)
- Update _register_missing_plugin_models method signature to remove feature_mixins_map parameter
- Simplify _is_model_registered to use registry['models'] structure instead of feature-based checking
- Bump version to 4.4.0.1 to reflect NetBox 4.4 compatibility

Fixes ImportError: cannot import name 'FEATURES_MAP' from 'netbox.models.features' Related to NetBox issue #20129 - dynamic model feature registration system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Ensures plugin models are correctly recognized using the current NetBox registry structure, reducing missed or duplicate registrations.
  - Improves stability and compatibility with NetBox 4.4.

- Refactor
  - Streamlined internal model-registration checks to rely on a single registry source for accuracy and performance.

- Chores
  - Bumped version to 4.4.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->